### PR TITLE
Release 0.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.nyc_output/
-coverage/
 node_modules/
 *.log
+
+.nyc_output/
+coverage/

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,9 @@
+.nyc_output/
 coverage/
+codecov.yml
+
 test/
 .*
 AUTHORS.md
 CHANGES.md
-codecov.yml
 CONTRIBUTING.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,15 @@ sudo: false
 language: node_js
 node_js:
   - "8"
+  - "9"
 script:
   - npm test
 after_success:
   - npm run coverage
 notifications:
+  email: false
   slack:
     rooms:
       - secure: Bu+WX8d4eWg+hubGeMZQ5j/mdt0LmRbohp3NO9DQGi2/026Z7N/tGkienEaD8oOQY3ZORaQuGbMCLBHrMWUIAz8kaeMqtvRjj3a8ZGNVZ/2kFLwv2gQnMGkigULZNbDFKRd6I7WkEfOUU4ANsXNDzsfdM3h2jXbIGew922adF0GkQGm8npLAfshj32Mogwe1oU78pVFukW8TcWrL2iZDRaBk2mrPYfTyP3scbdYeOIDDgWvnV0DkXHP2oPI9mMjzuIOBEXF5cBv7wMMHOu1/dtZzN/zrMB1Hm0iFsdb2TT8NgpTjaxb3y0JuEgC+e1TB6VznZ53HwED5G4eDBFE7Nz4iJ1y4rMTOzDxqMhXPOgwD4DOg2JDgZeT3bm1De63fpeM7vbfuZnGAnm5u9NR2ylVcH0yCCfdH0WV0nhA+k384MQH/WJe1xerrIu7kMOh6VyM7BxgDvpROn3vWrkWfPWufXeyX8ZSaA2j0OcYpQ4nfF2dhsmCEMeKhNU5AgdJhCVa97STsLz8lH9RMSrYz95HH/y6Yz3YZ6te+lCZLokNjo3vO89+hoUHCe5obxwxD9zLWsBhtxtKKgzLGn45JSZOA5zr3QNhQlzw8FkDBrVyLlYKUoP2+kW8eZpTM0udRClSrquXf1Kf0pbReKHemrK73arSMesd/FAjM8hRCtIA=
+    on_failure: change
     on_success: change

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Version 0.1.2, 2018.01.25
+
+* Move Unicode escape and unescape logic out to new `escape-unicode` and `unescape-unicode` modules respectively
+* Configure travis to also build against Node.js v9
+* Replace `chai` with `assert` in unit tests
+* Bump dependencies
+
 ## Version 0.1.1, 2017.12.09
 
 * Fix require statements in README examples [#2](https://github.com/NotNinja/nevis/issues/2)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (C) 2017 Alasdair Mercer, !ninja
+Copyright (C) 2018 Alasdair Mercer, !ninja
 
 Permission is hereby granted, free of charge, to any person obtaining a copy  
 of this software and associated documentation files (the "Software"), to deal  

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ $ cat ascii.properties | native2ascii --reverse > utf8.properties
 
 ## API
 
-    native2ascii(input[, options])
+### native2ascii(input[, options])
 
 Converts the specified `input` so that it can be encoded in ASCII by using Unicode escapes ("\uxxxx" notation) for all
 characters that are not part of the ASCII character set.
@@ -97,13 +97,13 @@ This function is useful for properties files containing characters not in ISO-88
 
 A reverse conversion can be performed by enabling the `reverse` option.
 
-### Options
+#### Options
 
 | Option    | Description                      | Default |
 | --------- | -------------------------------- | ------- |
 | `reverse` | Whether to reverse the operation | `false` |
 
-### Examples
+#### Examples
 
 Unicode escape characters not in the ASCII character set so that they can be safely written encoded into ASCII:
 

--- a/bin/native2ascii
+++ b/bin/native2ascii
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /*
- * Copyright (C) 2017 Alasdair Mercer, !ninja
+ * Copyright (C) 2018 Alasdair Mercer, !ninja
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "unescape-unicode": "^0.1.0"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
     "codecov": "^3.0.0",
     "eslint": "^4.16.0",
     "eslint-config-notninja": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -25,16 +25,16 @@
     "url": "https://github.com/NotNinja/node-native2ascii.git"
   },
   "dependencies": {
-    "commander": "^2.12.2"
+    "commander": "^2.13.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "codecov": "^3.0.0",
-    "eslint": "^4.13.0",
+    "eslint": "^4.16.0",
     "eslint-config-notninja": "^0.2.3",
-    "mocha": "^4.0.1",
-    "nyc": "^11.3.0",
-    "sinon": "^4.1.3",
+    "mocha": "^5.0.0",
+    "nyc": "^11.4.1",
+    "sinon": "^4.2.1",
     "tmp": "0.0.33"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "url": "https://github.com/NotNinja/node-native2ascii.git"
   },
   "dependencies": {
-    "commander": "^2.13.0"
+    "commander": "^2.13.0",
+    "escape-unicode": "^0.1.0",
+    "unescape-unicode": "^0.1.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-native2ascii",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Node.js implementation of Java's Native-to-ASCII Converter",
   "homepage": "https://github.com/NotNinja/node-native2ascii",
   "bugs": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Alasdair Mercer, !ninja
+ * Copyright (C) 2018 Alasdair Mercer, !ninja
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/native2ascii.js
+++ b/src/native2ascii.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Alasdair Mercer, !ninja
+ * Copyright (C) 2018 Alasdair Mercer, !ninja
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/unicode/escape.js
+++ b/src/unicode/escape.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Alasdair Mercer, !ninja
+ * Copyright (C) 2018 Alasdair Mercer, !ninja
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/unicode/escape.js
+++ b/src/unicode/escape.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const hexDigits = [ '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' ];
+const escapeUnicode = require('escape-unicode');
 
 /**
  * Converts all Unicode characters within the specifed <code>input</code> to Unicode escapes ("\uxxxx" notation).
@@ -37,36 +37,13 @@ function escape(input) {
     const code = input.charCodeAt(i);
 
     if (code > 0x7f) {
-      result += `\\u${toHex(code)}`;
+      result += escapeUnicode(input, i, i + 1);
     } else {
-      result += input.charAt(i);
+      result += input[i];
     }
   }
 
   return result;
-}
-
-/**
- * Converts the specified character <code>code</code> to a hexadecimal value.
- *
- * @param {number} code - the character code to be converted
- * @return {string} The 4-digit hexadecimal string.
- */
-function toHex(code) {
-  return toHexDigit((code >> 12) & 15) +
-    toHexDigit((code >> 8) & 15) +
-    toHexDigit((code >> 4) & 15) +
-    toHexDigit(code & 15);
-}
-
-/**
- * Converts the specified <code>nibble</code> to a hexadecimal digit.
- *
- * @param {number} nibble - the nibble to be converted
- * @return {string} The single-digit hexadecimal string.
- */
-function toHexDigit(nibble) {
-  return hexDigits[nibble & 15];
 }
 
 module.exports = escape;

--- a/src/unicode/index.js
+++ b/src/unicode/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Alasdair Mercer, !ninja
+ * Copyright (C) 2018 Alasdair Mercer, !ninja
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/unicode/unescape.js
+++ b/src/unicode/unescape.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Alasdair Mercer, !ninja
+ * Copyright (C) 2018 Alasdair Mercer, !ninja
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/unicode/unescape.js
+++ b/src/unicode/unescape.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-/* eslint complexity: "off" */
+const unescapeUnicode = require('unescape-unicode');
 
 /**
  * Converts all Unicode escapes ("\uxxxx" notation) within the specified <code>input</code> into their corresponding
@@ -38,13 +38,13 @@ function unescape(input) {
   let result = '';
 
   for (let i = 0, length = input.length; i < length; i++) {
-    let ch = input.charAt(i);
+    let ch = input[i];
 
     if (ch === '\\') {
-      ch = input.charAt(++i);
+      ch = input[++i];
 
       if (ch === 'u') {
-        result += getUnicode(input, i + 1);
+        result += unescapeUnicode(input, i + 1);
         i += 4;
       } else {
         result += `\\${ch}`;
@@ -55,65 +55,6 @@ function unescape(input) {
   }
 
   return result;
-}
-
-/**
- * Attempts to convert the Unicode escape within <code>input</code> at the specified <code>offset</code>.
- *
- * <code>offset</code> should be the index of the first character after the "\u" prefix of the Unicode escape and will
- * result in the offset being increased as it reads in the next four characters within <code>input</code>.
- *
- * This function will throw an error if the hexadecimal value corresponding to the Unicode escape at the specified
- * <code>offset</code> is malformed.
- *
- * @param {string} input - the string to be converted
- * @param {number} offset - the offset of the hexadecimal segment of the Unicode escape from which the Unicode character
- * is to be derived relative to <code>input</code>
- * @return {string} The Unicode character converted from the escape at <code>offset</code> within <code>input</code>.
- * @throws {Error} If the Unicode escape is malformed.
- */
-function getUnicode(input, offset) {
-  let unicode = 0;
-
-  for (let i = offset, end = offset + 4; i < end; i++) {
-    const ch = input.charAt(i);
-    const code = ch.charCodeAt(0);
-
-    switch (ch) {
-    case '0':
-    case '1':
-    case '2':
-    case '3':
-    case '4':
-    case '5':
-    case '6':
-    case '7':
-    case '8':
-    case '9':
-      unicode = (unicode << 4) + code - 0x30;
-      break;
-    case 'A':
-    case 'B':
-    case 'C':
-    case 'D':
-    case 'E':
-    case 'F':
-      unicode = (unicode << 4) + 10 + code - 0x41;
-      break;
-    case 'a':
-    case 'b':
-    case 'c':
-    case 'd':
-    case 'e':
-    case 'f':
-      unicode = (unicode << 4) + 10 + code - 0x61;
-      break;
-    default:
-      throw new Error(`Malformed character found in \\uxxxx encoding: ${ch}`);
-    }
-  }
-
-  return String.fromCharCode(unicode);
 }
 
 module.exports = unescape;

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Alasdair Mercer, !ninja
+ * Copyright (C) 2018 Alasdair Mercer, !ninja
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const { expect } = require('chai');
+const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const sinon = require('sinon');
@@ -111,7 +111,7 @@ describe('cli', () => {
 
         await cli.parse([ null, null ], options);
 
-        expect(options.stdout.buffer).to.deep.equal(expected);
+        assert.deepEqual(options.stdout.buffer, expected);
       });
 
       context('and STDIN is empty', () => {
@@ -120,7 +120,7 @@ describe('cli', () => {
 
           await cli.parse([ null, null ], options);
 
-          expect(options.stdout.buffer).to.deep.equal(expected);
+          assert.deepEqual(options.stdout.buffer, expected);
         });
       });
 
@@ -134,7 +134,7 @@ describe('cli', () => {
 
           await cli.parse([ null, null ], options);
 
-          expect(options.stdout.buffer).to.deep.equal(expected);
+          assert.deepEqual(options.stdout.buffer, expected);
         });
       });
 
@@ -148,12 +148,12 @@ describe('cli', () => {
           try {
             await cli.parse([ null, null ], options);
             // Should have thrown
-            expect.fail();
+            assert.fail();
           } catch (e) {
-            expect(e).to.equal(expectedError);
+            assert.strictEqual(e, expectedError);
           }
 
-          expect(options.stdout.buffer).to.deep.equal(expected);
+          assert.deepEqual(options.stdout.buffer, expected);
         });
       });
 
@@ -169,12 +169,12 @@ describe('cli', () => {
           try {
             await cli.parse([ null, null ], options);
             // Should have thrown
-            expect.fail();
+            assert.fail();
           } catch (e) {
-            expect(e).to.equal(expectedError);
+            assert.strictEqual(e, expectedError);
           }
 
-          expect(options.stdout.buffer).to.deep.equal(expected);
+          assert.deepEqual(options.stdout.buffer, expected);
         });
       });
 
@@ -190,7 +190,7 @@ describe('cli', () => {
             '--encoding', 'latin1'
           ], options);
 
-          expect(options.stdout.buffer).to.deep.equal(expected);
+          assert.deepEqual(options.stdout.buffer, expected);
         });
 
         context('and value is invalid', () => {
@@ -206,13 +206,13 @@ describe('cli', () => {
                 '--encoding', 'foo'
               ], options);
               // Should have thrown
-              expect.fail();
+              assert.fail();
             } catch (e) {
-              expect(e).to.be.an('error');
-              expect(e.message).to.equal('Invalid encoding: foo');
+              assert.ok(e instanceof Error);
+              assert.equal(e.message, 'Invalid encoding: foo');
             }
 
-            expect(options.stdout.buffer).to.deep.equal(expected);
+            assert.deepEqual(options.stdout.buffer, expected);
           });
         });
       });
@@ -229,7 +229,7 @@ describe('cli', () => {
             '--reverse'
           ], options);
 
-          expect(options.stdout.buffer).to.deep.equal(expected);
+          assert.deepEqual(options.stdout.buffer, expected);
         });
       });
 
@@ -246,7 +246,7 @@ describe('cli', () => {
             '--reverse'
           ], options);
 
-          expect(options.stdout.buffer).to.deep.equal(expected);
+          assert.deepEqual(options.stdout.buffer, expected);
         });
       });
     });
@@ -282,7 +282,7 @@ describe('cli', () => {
         const actual = await readFile(outputFile);
         const expected = await readFile(path.resolve(__dirname, './fixtures/escaped/latin1-from-utf8.txt'));
 
-        expect(actual).to.deep.equal(expected);
+        assert.deepEqual(actual, expected);
       });
 
       context('and input file is empty', () => {
@@ -296,7 +296,7 @@ describe('cli', () => {
           const actual = await readFile(outputFile);
           const expected = Buffer.alloc(0);
 
-          expect(actual).to.deep.equal(expected);
+          assert.deepEqual(actual, expected);
         });
       });
 
@@ -312,7 +312,7 @@ describe('cli', () => {
           const actual = await readFile(outputFile);
           const expected = await readFile(path.resolve(__dirname, './fixtures/escaped/latin1-from-latin1.txt'));
 
-          expect(actual).to.deep.equal(expected);
+          assert.deepEqual(actual, expected);
         });
 
         context('and value is invalid', () => {
@@ -325,16 +325,16 @@ describe('cli', () => {
                 outputFile
               ], options);
               // Should have thrown
-              expect.fail();
+              assert.fail();
             } catch (e) {
-              expect(e).to.be.an('error');
-              expect(e.message).to.equal('Invalid encoding: foo');
+              assert.ok(e instanceof Error);
+              assert.equal(e.message, 'Invalid encoding: foo');
             }
 
             const actual = await readFile(outputFile);
             const expected = Buffer.alloc(0);
 
-            expect(actual).to.deep.equal(expected);
+            assert.deepEqual(actual, expected);
           });
         });
       });
@@ -351,7 +351,7 @@ describe('cli', () => {
           const actual = await readFile(outputFile);
           const expected = await readFile(path.resolve(__dirname, './fixtures/unescaped/utf8.txt'));
 
-          expect(actual).to.deep.equal(expected);
+          assert.deepEqual(actual, expected);
         });
       });
 
@@ -368,7 +368,7 @@ describe('cli', () => {
           const actual = await readFile(outputFile);
           const expected = await readFile(path.resolve(__dirname, './fixtures/unescaped/latin1.txt'));
 
-          expect(actual).to.deep.equal(expected);
+          assert.deepEqual(actual, expected);
         });
       });
     });
@@ -399,10 +399,10 @@ describe('cli', () => {
             '--help'
           ], options);
           // Stubbed process.exit should have thrown
-          expect.fail();
+          assert.fail();
         } catch (e) {
-          expect(process.stdout.write.callCount).to.equal(1);
-          expect(process.stdout.write.getCall(0).args).to.deep.equal([
+          assert.equal(process.stdout.write.callCount, 1);
+          assert.deepEqual(process.stdout.write.getCall(0).args, [
             `
   Usage: native2ascii [options] [inputfile] [outputfile]
 
@@ -415,8 +415,8 @@ describe('cli', () => {
     -h, --help                 output usage information
 `
           ]);
-          expect(process.exit.callCount).to.be.at.least(1);
-          expect(process.exit.getCall(0).args).to.deep.equal([ 0 ]);
+          assert.ok(process.exit.callCount >= 1);
+          assert.deepEqual(process.exit.getCall(0).args, [ 0 ]);
         } finally {
           cleanUp();
         }
@@ -449,15 +449,15 @@ describe('cli', () => {
             '--version'
           ], options);
           // Stubbed process.exit should have thrown
-          expect.fail();
+          assert.fail();
         } catch (e) {
-          expect(process.stdout.write.callCount).to.equal(1);
-          expect(process.stdout.write.getCall(0).args).to.deep.equal([
+          assert.equal(process.stdout.write.callCount, 1);
+          assert.deepEqual(process.stdout.write.getCall(0).args, [
             `${version}
 `
           ]);
-          expect(process.exit.callCount).to.be.at.least(1);
-          expect(process.exit.getCall(0).args).to.deep.equal([ 0 ]);
+          assert.ok(process.exit.callCount >= 1);
+          assert.deepEqual(process.exit.getCall(0).args, [ 0 ]);
         } finally {
           cleanUp();
         }
@@ -469,7 +469,7 @@ describe('cli', () => {
     it('should write message to stderr', () => {
       cli.writeError('foo', options);
 
-      expect(options.stderr.buffer.toString()).to.equal('foo\n');
+      assert.equal(options.stderr.buffer.toString(), 'foo\n');
     });
   });
 });

--- a/test/native2ascii.spec.js
+++ b/test/native2ascii.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Alasdair Mercer, !ninja
+ * Copyright (C) 2018 Alasdair Mercer, !ninja
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/native2ascii.spec.js
+++ b/test/native2ascii.spec.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const { expect } = require('chai');
+const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const util = require('util');
@@ -34,14 +34,14 @@ const readFile = util.promisify(fs.readFile);
 describe('native2ascii', () => {
   context('when input is null', () => {
     it('should return null', () => {
-      expect(native2ascii(null)).to.equal(null);
+      assert.strictEqual(native2ascii(null), null);
     });
   });
 
   context('when input is undefined', () => {
     it('should return undefined', () => {
       /* eslint-disable no-undefined */
-      expect(native2ascii(undefined)).to.equal(undefined);
+      assert.strictEqual(native2ascii(undefined), undefined);
       /* eslint-enable no-undefined */
     });
   });
@@ -52,7 +52,7 @@ describe('native2ascii', () => {
       const expected = await readFile(path.resolve(__dirname, './fixtures/escaped/latin1-from-utf8.txt'), 'latin1');
       const actual = native2ascii(input);
 
-      expect(actual).to.equal(expected);
+      assert.equal(actual, expected);
     });
 
     context('and input is empty', () => {
@@ -60,7 +60,7 @@ describe('native2ascii', () => {
         const expected = '';
         const actual = native2ascii('');
 
-        expect(actual).to.equal(expected);
+        assert.equal(actual, expected);
       });
     });
   });
@@ -69,9 +69,9 @@ describe('native2ascii', () => {
     it('should escape all non-ASCII characters within input', async() => {
       const input = await readFile(path.resolve(__dirname, './fixtures/unescaped/utf8.txt'), 'utf8');
       const expected = await readFile(path.resolve(__dirname, './fixtures/escaped/latin1-from-utf8.txt'), 'latin1');
-      const actual = native2ascii(input);
+      const actual = native2ascii(input, { reverse: false });
 
-      expect(actual).to.equal(expected, { reverse: false });
+      assert.equal(actual, expected);
     });
 
     context('and input is empty', () => {
@@ -79,7 +79,7 @@ describe('native2ascii', () => {
         const expected = '';
         const actual = native2ascii('', { reverse: false });
 
-        expect(actual).to.equal(expected);
+        assert.equal(actual, expected);
       });
     });
   });
@@ -90,7 +90,7 @@ describe('native2ascii', () => {
       const expected = await readFile(path.resolve(__dirname, './fixtures/unescaped/utf8.txt'), 'utf8');
       const actual = native2ascii(input, { reverse: true });
 
-      expect(actual).to.equal(expected);
+      assert.equal(actual, expected);
     });
 
     context('and input is empty', () => {
@@ -98,7 +98,7 @@ describe('native2ascii', () => {
         const expected = '';
         const actual = native2ascii('', { reverse: true });
 
-        expect(actual).to.equal(expected);
+        assert.equal(actual, expected);
       });
     });
   });

--- a/test/unicode/escape.spec.js
+++ b/test/unicode/escape.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Alasdair Mercer, !ninja
+ * Copyright (C) 2018 Alasdair Mercer, !ninja
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/unicode/escape.spec.js
+++ b/test/unicode/escape.spec.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const { expect } = require('chai');
+const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const util = require('util');
@@ -37,7 +37,7 @@ describe('unicode/escape', () => {
     const expected = await readFile(path.resolve(__dirname, '../fixtures/escaped/latin1-from-ascii.txt'), 'ascii');
     const actual = escape(input);
 
-    expect(actual).to.equal(expected);
+    assert.equal(actual, expected);
   });
 
   it('should only escape non-ASCII characters within ISO-8859-1 character set', async() => {
@@ -45,7 +45,7 @@ describe('unicode/escape', () => {
     const expected = await readFile(path.resolve(__dirname, '../fixtures/escaped/latin1-from-latin1.txt'), 'latin1');
     const actual = escape(input);
 
-    expect(actual).to.equal(expected);
+    assert.equal(actual, expected);
   });
 
   it('should only escape non-ASCII characters within UTF-8 character set', async() => {
@@ -53,7 +53,7 @@ describe('unicode/escape', () => {
     const expected = await readFile(path.resolve(__dirname, '../fixtures/escaped/latin1-from-utf8.txt'), 'latin1');
     const actual = escape(input);
 
-    expect(actual).to.equal(expected);
+    assert.equal(actual, expected);
   });
 
   context('when input is empty', () => {
@@ -61,7 +61,7 @@ describe('unicode/escape', () => {
       const expected = '';
       const actual = escape('');
 
-      expect(actual).to.equal(expected);
+      assert.equal(actual, expected);
     });
   });
 });

--- a/test/unicode/index.spec.js
+++ b/test/unicode/index.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Alasdair Mercer, !ninja
+ * Copyright (C) 2018 Alasdair Mercer, !ninja
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/unicode/index.spec.js
+++ b/test/unicode/index.spec.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const { expect } = require('chai');
+const assert = require('assert');
 
 const escape = require('../../src/unicode/escape');
 const index = require('../../src/unicode/index');
@@ -30,7 +30,7 @@ const unescape = require('../../src/unicode/unescape');
 
 describe('unicode/index', () => {
   it('should export correct functions', () => {
-    expect(index.escape).to.equal(escape);
-    expect(index.unescape).to.equal(unescape);
+    assert.equal(index.escape, escape);
+    assert.equal(index.unescape, unescape);
   });
 });

--- a/test/unicode/unescape.spec.js
+++ b/test/unicode/unescape.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Alasdair Mercer, !ninja
+ * Copyright (C) 2018 Alasdair Mercer, !ninja
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/unicode/unescape.spec.js
+++ b/test/unicode/unescape.spec.js
@@ -76,7 +76,11 @@ describe('unicode/unescape', () => {
     it('should throw an error', () => {
       expect(() => {
         unescape('\\u00ah');
-      }).to.throw(Error, 'Malformed character found in \\uxxxx encoding: h');
+      }).to.throw(Error, 'Unexpected character "h" found at 5');
+
+      expect(() => {
+        unescape('\\u00a');
+      }).to.throw(Error, 'Insufficient characters found: -1');
     });
   });
 });

--- a/test/unicode/unescape.spec.js
+++ b/test/unicode/unescape.spec.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const { expect } = require('chai');
+const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const util = require('util');
@@ -37,7 +37,7 @@ describe('unicode/unescape', () => {
     const expected = await readFile(path.resolve(__dirname, '../fixtures/unescaped/ascii.txt'), 'ascii');
     const actual = unescape(input);
 
-    expect(actual).to.equal(expected);
+    assert.equal(actual, expected);
   });
 
   it('should only unescape escaped unicode values within ISO-8859-1 character set', async() => {
@@ -45,7 +45,7 @@ describe('unicode/unescape', () => {
     const expected = await readFile(path.resolve(__dirname, '../fixtures/unescaped/latin1.txt'), 'latin1');
     const actual = unescape(input);
 
-    expect(actual).to.equal(expected);
+    assert.equal(actual, expected);
   });
 
   it('should only unescape escaped unicode values within UTF-8 character set', async() => {
@@ -53,14 +53,14 @@ describe('unicode/unescape', () => {
     const expected = await readFile(path.resolve(__dirname, '../fixtures/unescaped/utf8.txt'), 'utf8');
     const actual = unescape(input);
 
-    expect(actual).to.equal(expected);
+    assert.equal(actual, expected);
   });
 
   it('should ignore case when unescaping escaped unicode values', () => {
     const expected = '\u001a\u001b\u001c\u001d\u001e\u001f';
     const actual = unescape('\\u001A\\u001B\\u001C\\u001D\\u001E\\u001F');
 
-    expect(actual).to.equal(expected);
+    assert.equal(actual, expected);
   });
 
   context('when input is empty', () => {
@@ -68,19 +68,23 @@ describe('unicode/unescape', () => {
       const expected = '';
       const actual = unescape('');
 
-      expect(actual).to.equal(expected);
+      assert.equal(actual, expected);
     });
   });
 
   context('when input contains invalid escaped unicode value', () => {
     it('should throw an error', () => {
-      expect(() => {
+      assert.throws(() => {
         unescape('\\u00ah');
-      }).to.throw(Error, 'Unexpected character "h" found at 5');
+      }, (error) => {
+        return error instanceof Error && error.message === 'Unexpected character "h" found at 5';
+      });
 
-      expect(() => {
+      assert.throws(() => {
         unescape('\\u00a');
-      }).to.throw(Error, 'Insufficient characters found: -1');
+      }, (error) => {
+        return error instanceof Error && error.message === 'Insufficient characters found: -1';
+      });
     });
   });
 });


### PR DESCRIPTION
- [x] Move Unicode escape and unescape logic out to new `escape-unicode` and `unescape-unicode` modules respectively
- [x] Configure travis to also build against Node.js v9
- [x] Replace `chai` with `assert` in unit tests
- [x] Bump dependencies